### PR TITLE
Feat 매물등록 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner'
 
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/kb/zipkim/domain/prop/controller/PropertyController.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/controller/PropertyController.java
@@ -1,13 +1,12 @@
 package com.kb.zipkim.domain.prop.controller;
 
 import com.kb.zipkim.domain.prop.dto.PropRegisterForm;
+import com.kb.zipkim.domain.prop.dto.RegisterResult;
 import com.kb.zipkim.domain.prop.file.FileStoreService;
-import com.kb.zipkim.domain.prop.file.FileStoreServicePC;
 import com.kb.zipkim.domain.prop.file.UploadFile;
 import com.kb.zipkim.domain.prop.service.PropertyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,9 +23,8 @@ public class PropertyController {
     private final FileStoreService fileStoreService;
 
     @PostMapping("/api/property")
-    public String createItem(@ModelAttribute PropRegisterForm propRegisterForm) throws IOException {
-        List<UploadFile> uploadFiles = fileStoreService.storeFiles(propRegisterForm.getImages());
-        return "ok";
+    public RegisterResult createProp(@ModelAttribute PropRegisterForm propRegisterForm) throws IOException {
+        return propertyService.registerProp(propRegisterForm);
     }
 
 }

--- a/src/main/java/com/kb/zipkim/domain/prop/dto/PropRegisterForm.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/dto/PropRegisterForm.java
@@ -8,6 +8,8 @@ import java.util.List;
 @Data
 public class PropRegisterForm {
 
+    private Long brokerId;
+
     private String zipcode;
 
     private String roadName;
@@ -50,6 +52,9 @@ public class PropRegisterForm {
     private String recentDeposit;
 
     private String hugNumber;
+
+    private Boolean hasSchool;
+    private Boolean hasConvenience;
 
 //  등기관련
 

--- a/src/main/java/com/kb/zipkim/domain/prop/dto/RegisterResult.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/dto/RegisterResult.java
@@ -1,0 +1,18 @@
+package com.kb.zipkim.domain.prop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterResult {
+
+    Long propId;
+    List<String> imageUrl = new ArrayList<>();
+}

--- a/src/main/java/com/kb/zipkim/domain/prop/entity/Property.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/entity/Property.java
@@ -1,7 +1,8 @@
 package com.kb.zipkim.domain.prop.entity;
 
+import com.kb.zipkim.domain.prop.dto.PropRegisterForm;
 import com.kb.zipkim.domain.prop.file.UploadFile;
-import com.kb.zipkim.domain.register.register.Registered;
+import com.kb.zipkim.domain.register.Registered;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +22,7 @@ public class Property {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long broker_id; //중개인
+    private Long brokerId; //중개인
 
     @OneToOne(fetch = FetchType.LAZY,cascade = CascadeType.ALL)
     @JoinColumn(name = "register_id")
@@ -71,9 +72,43 @@ public class Property {
 
     private String hugNumber;
 
-
+    private Boolean hasSchool;
+    private Boolean hasConvenience;
+    public static Property makeProperty(
+           PropRegisterForm form
+    ) {
+        Property property = new Property();
+        property.brokerId = form.getBrokerId();
+        property.zipcode = form.getZipcode();
+        property.roadName = form.getRoadName();
+        property.bgdCd = form.getBgdCd();
+        property.addressName = form.getAddressName();
+        property.mainAddressNo = form.getMainAddressNo();
+        property.subAddressNo = form.getSubAddressNo();
+        property.longitude = form.getLongitude();
+        property.latitude = form.getLatitude();
+        property.amount = form.getAmount();
+        property.deposit = form.getDeposit();
+        property.roomNo = form.getRoomNo();
+        property.bathNo = form.getBathNo();
+        property.hasEv = form.getHasEv();
+        property.porch = form.getPorch();
+        property.floor = form.getFloor();
+        property.totalFloor = form.getTotalFloor();
+        property.description = form.getDescription();
+        property.parking = form.getParking();
+        property.recentAmount = form.getRecentAmount();
+        property.recentDeposit = form.getRecentDeposit();
+        property.hugNumber = form.getHugNumber();
+        property.hasSchool = form.getHasSchool();
+        property.hasConvenience = form.getHasConvenience();
+        return property;
+    }
     public void register(Registered registered) {
         this.registered = registered;
     }
 
+    public void upload(List<UploadFile> images) {
+        this.images = images;
+    }
 }

--- a/src/main/java/com/kb/zipkim/domain/prop/file/FileStoreService.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/file/FileStoreService.java
@@ -4,16 +4,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 public abstract class FileStoreService {
-    @Value("${file.dir}")
-    private String fileDir;
+    abstract public String getFullPath(String filename);
 
-    public String getFullPath(String filename) {
-        return fileDir + filename;
-    }
     String createStoreFileName(String originalFilename) {
         String ext = extractExt(originalFilename);
         String uuid = UUID.randomUUID().toString();
@@ -24,7 +21,15 @@ public abstract class FileStoreService {
         return originalFilename.substring(pos + 1);
     }
 
-    abstract public List<UploadFile> storeFiles(List<MultipartFile> multipartFiles) throws IOException;
+    public List<UploadFile> storeFiles(List<MultipartFile> multipartFiles) throws IOException {
+        List<UploadFile> storeFileResult = new ArrayList<>();
+        for (MultipartFile multipartFile : multipartFiles) {
+            if (!multipartFile.isEmpty()) {
+                storeFileResult.add(storeFile(multipartFile));
+            }
+        }
+        return storeFileResult;
+    }
 
     abstract public UploadFile storeFile(MultipartFile multipartFile) throws IOException;
 

--- a/src/main/java/com/kb/zipkim/domain/prop/file/FileStoreServiceAWS.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/file/FileStoreServiceAWS.java
@@ -1,22 +1,50 @@
 package com.kb.zipkim.domain.prop.file;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @Profile("prod")
+@RequiredArgsConstructor
 public class FileStoreServiceAWS extends FileStoreService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final AmazonS3 s3Client;
+
     @Override
-    public List<UploadFile> storeFiles(List<MultipartFile> multipartFiles) throws IOException {
-        return List.of();
+    public String getFullPath(String filename) {
+        URL url = s3Client.getUrl(bucketName, filename);
+        return url.toString();
     }
+
 
     @Override
     public UploadFile storeFile(MultipartFile multipartFile) throws IOException {
-        return null;
+        if (multipartFile.isEmpty()) {
+            return null;
+        }
+        String originalFilename = multipartFile.getOriginalFilename();
+        String storeFileName = createStoreFileName(originalFilename);
+
+        // S3에 파일업로드
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(multipartFile.getContentType());
+        metadata.setContentLength(multipartFile.getSize());
+
+        s3Client.putObject(bucketName, storeFileName, multipartFile.getInputStream(), metadata);
+        return new UploadFile(originalFilename, storeFileName);
     }
 }

--- a/src/main/java/com/kb/zipkim/domain/prop/file/FileStoreServicePC.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/file/FileStoreServicePC.java
@@ -15,16 +15,15 @@ import java.util.UUID;
 @Profile("local")
 public class FileStoreServicePC extends FileStoreService {
 
-    public List<UploadFile> storeFiles(List<MultipartFile> multipartFiles)
-            throws IOException {
-        List<UploadFile> storeFileResult = new ArrayList<>();
-        for (MultipartFile multipartFile : multipartFiles) {
-            if (!multipartFile.isEmpty()) {
-                storeFileResult.add(storeFile(multipartFile));
-            } }
-        return storeFileResult;
+    @Value("${file.dir}")
+    private String fileDir;
+
+    @Override
+    public String getFullPath(String filename) {
+        return fileDir + filename;
     }
 
+    @Override
     public UploadFile storeFile(MultipartFile multipartFile) throws IOException
     {
         if (multipartFile.isEmpty()) {

--- a/src/main/java/com/kb/zipkim/domain/prop/service/PropertyService.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/service/PropertyService.java
@@ -1,13 +1,44 @@
 package com.kb.zipkim.domain.prop.service;
 
+import com.kb.zipkim.domain.prop.dto.PropRegisterForm;
+import com.kb.zipkim.domain.prop.dto.RegisterResult;
+import com.kb.zipkim.domain.prop.entity.Property;
+import com.kb.zipkim.domain.prop.file.FileStoreService;
+import com.kb.zipkim.domain.prop.file.UploadFile;
 import com.kb.zipkim.domain.prop.repository.PropertyRepository;
+import com.kb.zipkim.domain.register.Registered;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PropertyService {
 
     private final PropertyRepository propertyRepository;
+    private final FileStoreService fileStoreService;
+
+    @Transactional
+    public RegisterResult registerProp(PropRegisterForm form) throws IOException {
+        List<UploadFile> uploadFiles = fileStoreService.storeFiles(form.getImages());
+
+        Property property = Property.makeProperty(form);
+        Registered registered = Registered.builder()
+                .registerUniqueNum(form.getRegisterUniqueNum())
+                .build();
+        property.register(registered);
+        property.upload(uploadFiles);
+        propertyRepository.save(property);
+        RegisterResult result = new RegisterResult();
+        for (UploadFile uploadFile : uploadFiles) {
+            result.getImageUrl().add(fileStoreService.getFullPath(uploadFile.getStoreFileName()));
+        }
+        result.setPropId(property.getId());
+        return result;
+    }
 
 }

--- a/src/main/java/com/kb/zipkim/domain/register/Registered.java
+++ b/src/main/java/com/kb/zipkim/domain/register/Registered.java
@@ -1,4 +1,4 @@
-package com.kb.zipkim.domain.register.register;
+package com.kb.zipkim.domain.register;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/test/java/com/kb/zipkim/ZipkimApplicationTests.java
+++ b/src/test/java/com/kb/zipkim/ZipkimApplicationTests.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(classes = ZipkimApplication.class)
 class ZipkimApplicationTests {
 
     @Test

--- a/src/test/java/com/kb/zipkim/domain/prop/repository/PropertyRepositoryTest.java
+++ b/src/test/java/com/kb/zipkim/domain/prop/repository/PropertyRepositoryTest.java
@@ -1,13 +1,11 @@
 package com.kb.zipkim.domain.prop.repository;
 
 import com.kb.zipkim.domain.prop.entity.Property;
-import com.kb.zipkim.domain.register.register.Registered;
+import com.kb.zipkim.domain.register.Registered;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class PropertyRepositoryTest {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,4 +26,4 @@ server:
 serverName: local_server
 
 file:
-  dir: /home/ubuntu/images/
+  dir: ""


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #8 

## 📝작업 내용

> 매물등록 구현
> 이미지업로드는 환경에 따라 다르게 구현 
> 로컬(FileStoreServicePC), 원격(FileStoreServiceAWS)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
