### PR TITLE
Fix: 매물과 등기부 연관관계편의메서드 추가

### DIFF
--- a/src/main/java/com/kb/zipkim/domain/prop/entity/Property.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/entity/Property.java
@@ -109,6 +109,9 @@ public class Property {
     }
 
     public void upload(List<UploadFile> images) {
+        for (UploadFile image : images) {
+            image.setProperty(this);
+        }
         this.images = images;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8

## 📝작업 내용

>  매물과 등기부 연관관계편의메서드 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
