### PR TITLE
fix: 건물식별시  동이름 -> 법정동코드

### DIFF
--- a/src/main/java/com/kb/zipkim/domain/prop/controller/PropertyController.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/controller/PropertyController.java
@@ -10,10 +10,7 @@ import com.kb.zipkim.domain.prop.service.PropertyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,9 +28,9 @@ public class PropertyController {
         return propertyService.registerProp(propRegisterForm);
     }
 
-    @GetMapping("/api/nearProps")
-    public ResponseEntity<List<NearByComplex>> getNearItems(@ModelAttribute LocationWithRadius locationWithRadius) throws JsonProcessingException {
-        List<NearByComplex> props = propertyService.findNearProp(locationWithRadius.getLat(), locationWithRadius.getLon(), locationWithRadius.getRadius());
+    @GetMapping("/api/map/{type}")
+    public ResponseEntity<List<NearByComplex>> getNearComplexes(@PathVariable String type, @ModelAttribute LocationWithRadius locationWithRadius) throws JsonProcessingException {
+        List<NearByComplex> props = propertyService.findNearProp(type, locationWithRadius.getLat(), locationWithRadius.getLon(), locationWithRadius.getRadius());
         return ResponseEntity.ok().body(props);
     }
 }

--- a/src/main/java/com/kb/zipkim/domain/prop/dto/NearByComplex.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/dto/NearByComplex.java
@@ -1,6 +1,7 @@
 package com.kb.zipkim.domain.prop.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 import static org.springframework.util.StringUtils.*;
@@ -9,7 +10,6 @@ import static org.springframework.util.StringUtils.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@ToString
 public class NearByComplex {
     Long complexId;
 
@@ -26,10 +26,13 @@ public class NearByComplex {
     Double curDepositRatio;
     Double recentDepositRatio;
 
-    @JsonIgnore
+    Double longitude;
+
+    Double latitude;
+
     Double distance;
 
-    public NearByComplex(Long complexId,String type, Double currentAverageDeposit, Double currentAverageAmount, Double recentAmount, Double recentDeposit, Double curDepositRatio, Double recentDepositRatio) {
+    public NearByComplex(Long complexId,String type, Double currentAverageDeposit, Double currentAverageAmount, Double recentAmount, Double recentDeposit, Double curDepositRatio, Double recentDepositRatio, Double longitude, Double latitude) {
         this.complexId = complexId;
         this.type = type;
         this.currentAverageDeposit = currentAverageDeposit;
@@ -38,6 +41,8 @@ public class NearByComplex {
         this.recentDeposit = recentDeposit;
         this.curDepositRatio = curDepositRatio;
         this.recentDepositRatio = recentDepositRatio;
+        this.longitude = longitude;
+        this.latitude = latitude;
     }
 
 }

--- a/src/main/java/com/kb/zipkim/domain/prop/dto/PropRegisterForm.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/dto/PropRegisterForm.java
@@ -16,8 +16,6 @@ public class PropRegisterForm {
 
     private String zipcode;
 
-    private String dong;
-
     private String roadName;
 
     private String bgdCd;

--- a/src/main/java/com/kb/zipkim/domain/prop/entity/Complex.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/entity/Complex.java
@@ -26,8 +26,6 @@ public class Complex {
 
     private String zipcode;
 
-    private String dong;
-
     private String roadName;
 
     private String bgdCd;
@@ -59,7 +57,6 @@ public class Complex {
             PropRegisterForm form
     ) {
         Complex complex = new Complex();
-        complex.dong = form.getDong();
         complex.type = form.getType();
         complex.complexName = form.getComplexName();
         complex.zipcode = form.getZipcode();

--- a/src/main/java/com/kb/zipkim/domain/prop/redis/CacheWarmingService.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/redis/CacheWarmingService.java
@@ -36,7 +36,7 @@ public class CacheWarmingService {
         GeoOperations<String, String> geoOperations = redisTemplate.opsForGeo();
 
         for (Complex complex : all) {
-            NearByComplex nearByComplex = new NearByComplex(complex.getId(),complex.getType(), complex.calcAvrDeposit(), complex.calcAvrAmount(), complex.getRecentAmount(), complex.getRecentDeposit(), complex.calcCurrentDepositRatio(), complex.calcRecentDepositRatio());
+            NearByComplex nearByComplex = new NearByComplex(complex.getId(),complex.getType(), complex.calcAvrDeposit(), complex.calcAvrAmount(), complex.getRecentAmount(), complex.getRecentDeposit(), complex.calcCurrentDepositRatio(), complex.calcRecentDepositRatio(), complex.getLongitude(),complex.getLatitude());
             Point point = new Point(complex.getLongitude(), complex.getLatitude());
             geoOperations.add(KEY, point, objectMapper.writeValueAsString(nearByComplex));
         }

--- a/src/main/java/com/kb/zipkim/domain/prop/repository/ComplexRepository.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/repository/ComplexRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface ComplexRepository extends JpaRepository<Complex, Long> {
 
-    Optional<Complex> findByDongAndMainAddressNoAndSubAddressNo(String dong, String mainAddressNo, String subAddressNo);
+    Optional<Complex> findByBgdCdAndMainAddressNoAndSubAddressNo(String bgdCd, String mainAddressNo, String subAddressNo);
 }

--- a/src/main/java/com/kb/zipkim/domain/prop/service/PropertyService.java
+++ b/src/main/java/com/kb/zipkim/domain/prop/service/PropertyService.java
@@ -51,7 +51,7 @@ public class PropertyService {
         property.register(registered);
         property.upload(uploadFiles);
 
-        Complex complex = complexRepository.findByDongAndMainAddressNoAndSubAddressNo(form.getDong(), form.getMainAddressNo(), form.getSubAddressNo())
+        Complex complex = complexRepository.findByBgdCdAndMainAddressNoAndSubAddressNo(form.getBgdCd(), form.getMainAddressNo(), form.getSubAddressNo())
                 .orElseGet(()->{
                     Complex newComplex = Complex.makeComplex(form);
                     return complexRepository.save(newComplex);
@@ -67,7 +67,7 @@ public class PropertyService {
         return result;
     }
 
-    public List<NearByComplex> findNearProp(double latitude, double longitude, double radius) throws JsonProcessingException {
+    public List<NearByComplex> findNearProp(String type, double latitude, double longitude, double radius) throws JsonProcessingException {
         GeoOperations<String, String> geoOperations = redisTemplate.opsForGeo();
         GeoReference<String> reference = GeoReference.fromCoordinate(new Point(longitude, latitude));
         Distance distance = new Distance(radius, RedisGeoCommands.DistanceUnit.KILOMETERS);
@@ -85,6 +85,9 @@ public class PropertyService {
         for (GeoResult<RedisGeoCommands.GeoLocation<String>> result : results) {
             RedisGeoCommands.GeoLocation<String> location = result.getContent();
             NearByComplex complex = objectMapper.readValue(location.getName(), NearByComplex.class);
+            if (!complex.getType().equals(type) ) {
+                continue;
+            }
             complex.setDistance(result.getDistance().getValue());
             complexes.add(complex);
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28 

## 📝작업 내용

> 기존 건물식별 동이름,본번,부번 -> 법정동,본번,부번 으로 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
